### PR TITLE
Add --github-reponame-template, generalize optional placeholders

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -46,8 +46,14 @@ USER_AGENT = "gh:openzipkin-contrib/apache-release-verification"
     "--sourcedir-template",
     default="{module_or_project}-{version}",
     help="Specify the format of the expected top-level directory in the source "
-    "archive. Usable placeholders: module, project, dash_incubating, "
-    "version",
+    "archive. Usable placeholders: "
+    f"{', '.join(State.list_placeholder_keys())}",
+)
+@click.option(
+    "--github-reponame-template",
+    default="{incubator_dash}{project}{dash_module}.git",
+    help="Specify the format for the name of the GitHub repository of the project."
+    "Supports the same placeholders as --sourcedir-template.",
 )
 @click.option("-v", "--verbose", is_flag=True)
 def main(
@@ -60,6 +66,7 @@ def main(
     incubating: bool,
     zipname_template: str,
     sourcedir_template: str,
+    github_reponame_template: str,
     verbose: bool,
 ) -> None:
     configure_logging(verbose)
@@ -67,6 +74,7 @@ def main(
         f"Arguments: project={project} module={module} version={version} "
         f"incubating={incubating} verbose={verbose} "
         f"zipname_template={zipname_template} sourcedir_template={sourcedir_template} "
+        f"github_reponame_template={github_reponame_template} "
         f"gpg_key={gpg_key} git_hash={git_hash}"
     )
 
@@ -94,6 +102,7 @@ def main(
         incubating=incubating,
         zipname_template=zipname_template,
         sourcedir_template=sourcedir_template,
+        github_reponame_template=github_reponame_template,
         gpg_key=gpg_key,
         git_hash=git_hash,
     )


### PR DESCRIPTION
**Watch out, this is on top of #16**, you probably only want to look at the last commit if reviewing before that's merged.

This allows verifying Apache Zipkin Layout Factory 0.0.5 currently up for vote as follows:
    
```
python src/main.py --project zipkin --module zipkin-layout-factory \
    --version 0.0.5 --gpg-key 50D90C2C \
    --git-hash 23dbddb426b4113c4b8633808b9ff0df3454e201 --repo dev \
    --zipname-template 'apache-{module}{dash_incubating}-{version}-source-release' \
    --github-reponame-template '{incubator_dash}{module}.git'
```