### PR TITLE
Add more allowed differences between repo and source archive

### DIFF
--- a/src/checks.py
+++ b/src/checks.py
@@ -243,12 +243,14 @@ def _check_dircmp_only_either_allowed(diff: filecmp.dircmp) -> List[str]:
     allowed_left_only = [
         ".git",
         ".gitignore",
+        ".gitattributes",
+        ".travis.yml",
         ".mvn",
         "mvnw",
         "mvnw.cmd",
         "Jenkinsfile",
     ]
-    allowed_right_only: List[str] = []
+    allowed_right_only: List[str] = ["DEPENDENCIES"]
     # Check files only in the git checkout
     for filename in diff.left_only:
         if filename not in allowed_left_only:


### PR DESCRIPTION
In repo only: `.gitattributes`, `.travis.yml`

In source archive only: `DEPENDENCIES`

These were surfaced by Zipkin Layout Factory 0.0.5 currently up for vote.