### PR TITLE
Re-enable `mvn package` test

### DIFF
--- a/src/checks.py
+++ b/src/checks.py
@@ -487,4 +487,5 @@ checks = [
     check_license_is_apache_2,
     check_license_looks_good,
     check_no_binary_files,
+    check_build_and_test,
 ]


### PR DESCRIPTION
Just noticed this is hasn't been running for some reason. Raising a PR in case this is desired behavior. We'll likely want to make the build command configurable in the near future.