### PR TITLE
Make build-and-test command configurable, add heuristics

### DIFF
--- a/src/checks.py
+++ b/src/checks.py
@@ -513,12 +513,13 @@ def check_build_and_test(state: State) -> Optional[str]:
             errors += f"{strategy.name()}: {err}"
 
     if not executed_at_least_one:
-        errors = [
-            "Heuristics failed to figure out the way to build and test this release.",
-            "Please specify the build-and-test command as:",
-            "--build-and-test-command 'shell script'",
-            "(Possibly --build-and-test-command true)",
-        ]
+        print(
+            "[NOTICE] This source release does not seem to include a build or test \n"
+            "[NOTICE] command. For common build toolchains, heuristics try to figure\n"
+            "[NOTICE] out what to do, but they failed here. You can optionally\n"
+            "[NOTICE] provide a build-and-test command by re-running with:\n"
+            "[NOTICE] --build-and-test-command 'shell script'"
+        )
 
     if errors:
         return "\n".join(errors)

--- a/src/checks.py
+++ b/src/checks.py
@@ -501,13 +501,24 @@ def check_build_and_test(state: State) -> Optional[str]:
 
     strategies = [BuildAndTestMaven(), BuildAndTestNpm()]
     errors: List[str] = []
+    executed_at_least_one = False
 
     for strategy in strategies:
         if not strategy.should_run(state):
             continue
+        executed_at_least_one = True
+        print(f"Executing build-and-test for {strategy.name()}")
         err = strategy.run(state)
         if err is not None:
             errors += f"{strategy.name()}: {err}"
+
+    if not executed_at_least_one:
+        errors = [
+            "Heuristics failed to figure out the way to build and test this release.",
+            "Please specify the build-and-test command as:",
+            "--build-and-test-command 'shell script'",
+            "(Possibly --build-and-test-command true)",
+        ]
 
     if errors:
         return "\n".join(errors)

--- a/src/checks.py
+++ b/src/checks.py
@@ -4,6 +4,7 @@ import logging
 import os
 import traceback
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Union
 
 import apache_2_license
@@ -11,32 +12,19 @@ from helpers import print_error, sh, step
 from report import Report, Result
 
 
+@dataclass
 class State:
-    def __init__(
-        self,
-        project: str,
-        module: Optional[str],
-        version: str,
-        work_dir: str,
-        incubating: bool,
-        zipname_template: str,
-        sourcedir_template: str,
-        github_reponame_template: str,
-        gpg_key: str,
-        git_hash: str,
-        build_and_test_command: Optional[str],
-    ):
-        self.project = project
-        self.module = module
-        self.version = version
-        self.work_dir = work_dir
-        self.incubating = incubating
-        self.zipname_template = zipname_template
-        self.sourcedir_template = sourcedir_template
-        self.github_reponame_template = github_reponame_template
-        self.gpg_key = gpg_key
-        self.git_hash = git_hash
-        self.build_and_test_command = build_and_test_command
+    project: str
+    module: Optional[str]
+    version: str
+    work_dir: str
+    incubating: bool
+    zipname_template: str
+    sourcedir_template: str
+    github_reponame_template: str
+    gpg_key: str
+    git_hash: str
+    build_and_test_command: Optional[str]
 
     def _generate_optional_placeholders(
         self, key: str, value: str, condition: bool

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,7 @@ USER_AGENT = "gh:openzipkin-contrib/apache-release-verification"
 
 @click.command()
 @click.option("--project", default="zipkin")
-@click.option("--module", required=False)
+@click.option("--module")
 @click.option("--version", required=True)
 @click.option("--gpg-key", required=True, help="ID of GPG key used to sign the release")
 @click.option(
@@ -55,6 +55,12 @@ USER_AGENT = "gh:openzipkin-contrib/apache-release-verification"
     help="Specify the format for the name of the GitHub repository of the project."
     "Supports the same placeholders as --sourcedir-template.",
 )
+@click.option(
+    "--build-and-test-command",
+    help="Instead of built-in heuristics, use this command to build and "
+    "test the release. Executed with the exctracted source release archive "
+    "as the working directory.",
+)
 @click.option("-v", "--verbose", is_flag=True)
 def main(
     project: str,
@@ -67,6 +73,7 @@ def main(
     zipname_template: str,
     sourcedir_template: str,
     github_reponame_template: str,
+    build_and_test_command: Optional[str],
     verbose: bool,
 ) -> None:
     configure_logging(verbose)
@@ -75,6 +82,7 @@ def main(
         f"incubating={incubating} verbose={verbose} "
         f"zipname_template={zipname_template} sourcedir_template={sourcedir_template} "
         f"github_reponame_template={github_reponame_template} "
+        f"build_and_test_command={build_and_test_command} "
         f"gpg_key={gpg_key} git_hash={git_hash}"
     )
 
@@ -105,6 +113,7 @@ def main(
         github_reponame_template=github_reponame_template,
         gpg_key=gpg_key,
         git_hash=git_hash,
+        build_and_test_command=build_and_test_command,
     )
 
     # TODO this is the place to filter checks here with optional arguments


### PR DESCRIPTION
Tested as:

```
python src/main.py  --module zipkin-api --version 0.2.1 --gpg-key 50D90C2C \
    --git-hash f6e41b694f0083eb6212bf2986f589b2cf699f50 --repo dev \
    --zipname-template 'apache-{module}{dash_incubating}-{version}-source-release' \
    --github-reponame-template '{incubator_dash}{module}.git' \
    --build-and-test-command 'yaml-lint *.yaml'
```

Relevant part of the output:

```
> Running check: Source archive builds cleanly
>> Executing `yaml-lint *.yaml` in '/tmp/tmp2_1k85yw/unzipped/zipkin-api-0.2.1'
Checking the content of ["zipkin2-api.yaml", "zipkin-api.yaml"]
File : zipkin2-api.yaml, Syntax OK
File : zipkin-api.yaml, Syntax OK
Done.
```

Note that currently the heuristics will run _each_ test-and-build command that seems to be relevant. This is completely intentional (and is up for debate, should you feel the need)