### PR TITLE
Fix #25: Introduce multiple levels of failures

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -17,10 +17,6 @@ def substep(msg: str) -> None:
     logging.info(f"{Fore.CYAN}>> {msg}{Style.RESET_ALL}")
 
 
-def print_error(error: str) -> None:
-    logging.error(f"{Fore.RED}{error}{Style.RESET_ALL}")
-
-
 def sh(cmd: str, workdir: Optional[str] = None) -> int:
     msg = f"Executing `{cmd}`"
     if workdir is not None:

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import tempfile
 from typing import Optional
 
@@ -122,9 +123,11 @@ def main(
     if report.problem_count == 0:
         logging.info(f"{Fore.GREEN}Everything seems to be in order.{Style.RESET_ALL}")
     else:
-        raise click.ClickException(
-            f"{Fore.RED}Found {report.problem_count} " f"problems.{Style.RESET_ALL}"
+        logging.info(
+            f"{Fore.RED}Found {report.problem_count} "
+            f"potential problems.{Style.RESET_ALL}"
         )
+        sys.exit(1)
 
 
 def configure_logging(verbose: bool) -> None:

--- a/src/report.py
+++ b/src/report.py
@@ -1,4 +1,6 @@
 import logging
+from enum import Enum, auto
+from math import ceil, floor
 from typing import List, NamedTuple, Optional
 
 from colorama import Fore, Style
@@ -6,22 +8,42 @@ from colorama import Fore, Style
 from helpers import header
 
 
+class ResultKind(Enum):
+    PASS = auto()
+    FAIL = auto()
+    WARN = auto()
+    NOTE = auto()
+    ERROR = auto()
+
+
+RESULT_STYLES = {
+    ResultKind.PASS: Fore.GREEN,
+    ResultKind.FAIL: Fore.RED,
+    ResultKind.WARN: Fore.YELLOW,
+    ResultKind.NOTE: Fore.BLUE,
+    ResultKind.ERROR: Fore.RED,
+}
+
+
 class Result(NamedTuple):
     name: str
     hide_if_passing: bool
-    error: Optional[str]
+    message: Optional[str]
+    kind: ResultKind
 
     @staticmethod
     def passed(name: str, hide_if_passing: bool) -> "Result":
-        return Result(name, hide_if_passing, None)
+        return Result(name, hide_if_passing, None, ResultKind.PASS)
 
     @staticmethod
-    def failed(name: str, hide_if_passing: bool, error: str) -> "Result":
-        return Result(name, hide_if_passing, error)
+    def failed(
+        name: str, hide_if_passing: bool, message: str, kind: ResultKind
+    ) -> "Result":
+        return Result(name, hide_if_passing, message, kind)
 
     @property
     def is_passed(self) -> bool:
-        return self.error is None
+        return self.kind is ResultKind.PASS
 
 
 class Report(NamedTuple):
@@ -36,15 +58,20 @@ class Report(NamedTuple):
         return problems
 
 
+def color_result(msg: str, kind: ResultKind) -> str:
+    prefix = RESULT_STYLES.get(kind, "")
+    return f"{prefix}{msg}{Style.RESET_ALL}"
+
+
 def print_report(report: Report) -> None:
     header("Summary follows")
+    max_len = max(len(result.kind.name) for result in report.results)
     for result in report.results:
         if result.is_passed and result.hide_if_passing:
             continue
-        if result.is_passed:
-            prefix = f"[{Fore.GREEN}PASS{Style.RESET_ALL}]"
-        else:
-            prefix = f"[{Fore.RED}FAIL{Style.RESET_ALL}]"
-        logging.info(f"{prefix} {result.name}")
+        padding_left = " " * ceil((max_len - len(result.kind.name)) / 2.0)
+        padding_right = " " * floor((max_len - len(result.kind.name)) / 2.0)
+        prefix = color_result(result.kind.name, result.kind)
+        logging.info(f"[{padding_left}{prefix}{padding_right}] {result.name}")
         if not result.is_passed:
-            logging.info(result.error)
+            logging.info(result.message)


### PR DESCRIPTION
Highlights:
* Can now differentiate between "check failed" and "failed to run check" (latter gets printed as `[ERROR]`)
* Individual checks can return various error levels, depending on the severity of problems they find. For example, the build-and-test check reports a `FAIL` level problem if it knows how to run tests, but they fail; on the other hand it reports a `NOTE` level problem if it doesn't know how to run tests.
* Inline problem reporting is correctly colorized by level (with `NOTE` level stuff not colorized to prevent rainbow-induced confusion, I'm running out of colors here)
* Repo-Release archive comparison is downgraded to `WARN` until #20 is done
* Advanced mathematics are utilized to correctly add padding to the `[WARN]` prefixes in the summary

![2019-04-30-233809_983x717](https://user-images.githubusercontent.com/59982/56997845-089e2780-6ba1-11e9-8cce-59b336b754a3.png)