### PR TITLE
Fix #20: Per-project allowed repo-release diffs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -50,6 +50,7 @@ USER_AGENT = "gh:openzipkin-contrib/apache-release-verification"
     "archive. Usable placeholders: "
     f"{', '.join(State.list_placeholder_keys())}",
 )
+@click.option("--github-org", default="apache")
 @click.option(
     "--github-reponame-template",
     default="{incubator_dash}{project}{dash_module}.git",
@@ -73,6 +74,7 @@ def main(
     incubating: bool,
     zipname_template: str,
     sourcedir_template: str,
+    github_org: str,
     github_reponame_template: str,
     build_and_test_command: Optional[str],
     verbose: bool,
@@ -82,7 +84,7 @@ def main(
         f"Arguments: project={project} module={module} version={version} "
         f"incubating={incubating} verbose={verbose} "
         f"zipname_template={zipname_template} sourcedir_template={sourcedir_template} "
-        f"github_reponame_template={github_reponame_template} "
+        f"github_org={github_org} github_reponame_template={github_reponame_template} "
         f"build_and_test_command={build_and_test_command} "
         f"gpg_key={gpg_key} git_hash={git_hash}"
     )
@@ -111,6 +113,7 @@ def main(
         incubating=incubating,
         zipname_template=zipname_template,
         sourcedir_template=sourcedir_template,
+        github_org=github_org,
         github_reponame_template=github_reponame_template,
         gpg_key=gpg_key,
         git_hash=git_hash,


### PR DESCRIPTION
With this change we read `.asfignore` from the Git checkout if it
exists. For purposes of verifying that the git repo and the source
archive match, files whose filenames match any filename specified in
`.asfignore` is ignored. Note that there is currently no support for
either specifying folders in `.asfignore`, or wildcards. It's a strict,
filename-only match.

Test without `.asfignore`:

```
$ python src/main.py  --module zipkin-api --version 0.2.1 --gpg-key 50D90C2C \
    --git-hash bc3cd4af4108f2ff7522d0c2782a6bb856bc05dd --repo release \
    --zipname-template 'apache-{module}{dash_incubating}-{version}-source-release' \
    --github-reponame-template '{module}.git' \
    --github-org abesto
...
[WARN] Git tree at provided revision matches source archive
/tmp/tmpve7uk1ix/git/zipkin-api.git/javadoc is only in the git checkout
/tmp/tmpve7uk1ix/git/zipkin-api.git/package-lock.json is only in the git checkout
/tmp/tmpve7uk1ix/git/zipkin-api.git/package.json is only in the git checkout
/tmp/tmpve7uk1ix/git/zipkin-api.git/pom.xml is only in the git checkout
/tmp/tmpve7uk1ix/git/zipkin-api.git/src is only in the git checkout
/tmp/tmpve7uk1ix/git/zipkin-api.git/validate.test.js is only in the git checkout
The contents of the following files differ: zipkin2-api.yaml
```

Test with `.asfignore` committed into a fork:

```
$ python src/main.py  --module zipkin-api --version 0.2.1 --gpg-key 50D90C2C \
    --git-hash 3fa7beb2a2d6c7ec0f9e3f4965bbc3a19cc82a69 --repo release \
    --zipname-template 'apache-{module}{dash_incubating}-{version}-source-release' \
    --github-reponame-template '{module}.git' \
    --github-org abesto
...
[PASS] Git tree at provided revision matches source archive
```

`.asfignore` file used for the test:

```
javadoc
package-lock.json
package.json
pom.xml
validate.test.js
zipkin2-api.yaml
src
```